### PR TITLE
WiGLE Cellular .csv to .kml

### DIFF
--- a/Cellular-csvtokml.py
+++ b/Cellular-csvtokml.py
@@ -1,0 +1,39 @@
+import os
+import csv
+
+def csv_to_kml(csv_file, kml_file):
+    # Open CSV file for reading
+    with open(csv_file, 'r') as csvfile:
+        csvreader = csv.DictReader(csvfile)
+        # Open KML file for writing
+        with open(kml_file, 'w') as kmlfile:
+            kmlfile.write('<?xml version="1.0" encoding="UTF-8"?>\n')
+            kmlfile.write('<kml xmlns="http://www.opengis.net/kml/2.2">\n')
+            kmlfile.write('<Document>\n')
+            for row in csvreader:
+                # Extract relevant columns
+                lat, lon = row['trilat'], row['trilong']
+                network_id = row['id']
+                # Write Placemark with relevant information
+                kmlfile.write('<Placemark>\n')
+                kmlfile.write('<name>{}</name>\n'.format(network_id))
+                kmlfile.write('<description>ID: {}</description>\n'.format(network_id))
+                kmlfile.write('<Point>\n')
+                kmlfile.write('<coordinates>{},{},0</coordinates>\n'.format(lon, lat))
+                kmlfile.write('</Point>\n')
+                kmlfile.write('</Placemark>\n')
+            kmlfile.write('</Document>\n')
+            kmlfile.write('</kml>\n')
+
+def convert_csv_files_to_kml(input_dir):
+    # Iterate over files in the input directory
+    for file_name in os.listdir(input_dir):
+        if file_name.endswith('.csv'):
+            csv_file = os.path.join(input_dir, file_name)
+            kml_file = os.path.join(input_dir, os.path.splitext(file_name)[0] + '.kml')
+            csv_to_kml(csv_file, kml_file)
+
+# Specify the directory containing your CSV files
+input_directory = r'YOUR DIRECTORY'
+
+convert_csv_files_to_kml(input_directory)


### PR DESCRIPTION
Description:
This Python script converts CSV files to KML (Keyhole Markup Language) files, which are commonly used for geographic visualization, particularly with mapping applications like Google Maps. It extracts specific columns from the CSV file (trilat, trilong, and id) and creates Placemarks in the KML file based on this information. The resulting KML file can be imported into mapping software for visualization and analysis.

Libraries used:
- `os`: Provides functions for interacting with the operating system, used here to list files in a directory.
- `csv`: Allows reading and writing CSV files, utilized to parse the input CSV file.
  
How to use:
1. Specify the directory containing your CSV files in the `input_directory` variable.
2. Run the script, which will iterate through all CSV files in the specified directory.
3. For each CSV file, it will create a corresponding KML file with Placemarks based on the specified columns.

Note:
- Make sure to adjust the `input_directory` variable to point to the correct directory containing your CSV files before running the script.